### PR TITLE
Update date to remove plugin update error

### DIFF
--- a/code/syntax/code.php
+++ b/code/syntax/code.php
@@ -41,7 +41,7 @@ class syntax_plugin_code_code extends DokuWiki_Syntax_Plugin {
       return array(
         'author' => 'Christopher Smith',
         'email'  => 'chris@jalakai.co.uk',
-        'date'   => '2008-08-13',
+        'date'   => '2020-07-28',
         'name'   => 'Code Replacement Plugin',
         'desc'   => 'Replacement for Dokuwiki\'s own <code> handler, adds a title to the box.
                      Syntax: <code lang|title>, lang and title are optional. title does not support any dokuwiki markup.',

--- a/code/syntax/file.php
+++ b/code/syntax/file.php
@@ -38,7 +38,7 @@ class syntax_plugin_code_file extends DokuWiki_Syntax_Plugin {
       return array(
         'author' => 'Christopher Smith',
         'email'  => 'chris@jalakai.co.uk',
-        'date'   => '2008-08-13',
+        'date'   => '2020-07-28',
         'name'   => '<file> replacement plugin',
         'desc'   => 'Replacement for Dokuwiki\'s own <file> handler, adds a title to the box.
                      Syntax: <file|title>, title is optional and does not support any dokuwiki markup.',


### PR DESCRIPTION
When updating the plugin it keeps saying there's a new update since the date hasn't been updated in the new version. 